### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,13 +55,14 @@ You can achieve this by using a `docker-compose.yml` file as well:
 
 ```yaml
 version: "2"
-runner:
-  image: klud/gitlab-runner
-  container_name: arm-runner
-  restart: always
-  volumes:
-    - $(pwd)/.runner:/etc/gitlab-runner
-    - /var/run/docker.sock:/var/run/docker.sock
+services:
+    runner:
+      image: klud/gitlab-runner
+      container_name: arm-runner
+      restart: always
+      volumes:
+        - .)/.runner:/etc/gitlab-runner
+        - /var/run/docker.sock:/var/run/docker.sock
 ```
 
 ### Register runner


### PR DESCRIPTION
Update Readme.md to correct invalid docker-compose.yml description :
 - Add missing "services" keyword.
 - Change "$(pwd)" extrapolation by "." as docker-compose cannot use this interpolation correctly but is able to use relative paths.